### PR TITLE
Do not exit if file exists

### DIFF
--- a/server-side-encryption/recover.php
+++ b/server-side-encryption/recover.php
@@ -1809,6 +1809,7 @@
 						}
 					} else {
 						println("SKIP: $targetname ALREADY EXISTS");
+						$result = true;
 					}
 				} else {
 					debug("skipping this item because it is not a file...");


### PR DESCRIPTION
The documentation says, "already-existing files will be skipped", but currently, the script just stops execution if the target file already exists.

With this change, the whole script does not exit anymore if the target file already exists. This is helpful for unsupervised execution of the script.